### PR TITLE
refactor: improve ETH value calculations and query consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,10 @@ AND l.topic0 IN (0x[SIG1], 0x[SIG2], 0x[SIG3])
 ```sql
 amount / 1e18 AS eth_amount        -- Wei to ETH conversion
 -- ETH placeholder address: 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+
+-- CRITICAL: Always divide before aggregating to prevent uint256 overflow
+SUM(amount / 1e18) AS total_eth    -- ✅ Correct: divide first, then sum
+SUM(amount) / 1e18 AS total_eth    -- ❌ Wrong: can overflow on large sums
 ```
 
 ### Date Patterns

--- a/queries/membership_subscriptions___5521952.sql
+++ b/queries/membership_subscriptions___5521952.sql
@@ -2,7 +2,6 @@
 -- query name: Membership Subscriptions
 -- query link: https://dune.com/queries/5521952
 
-
 WITH towns_created AS (SELECT town_address
                        FROM dune.towns_protocol.result_towns_created),
 

--- a/queries/protocol_fees___5441008.sql
+++ b/queries/protocol_fees___5441008.sql
@@ -17,7 +17,7 @@ WITH subscription_tx AS (SELECT DISTINCT ms.tx_hash, ms.town_address
 
 -- Aggregate daily protocol fees by source using materialized ETH flows
      summary_membership_fees
-         AS (SELECT date_trunc('day', ef.block_time) AS day, SUM (ef.eth_amount) AS membership_revenue
+         AS (SELECT date_trunc('day', ef.block_time) AS day, SUM (ef.value / 1e18) AS membership_revenue
 FROM dune.towns_protocol.result_towns_eth_flows ef
     JOIN subscription_tx st
 ON ef.tx_hash = st.tx_hash AND ef."from" = st.town_address
@@ -26,7 +26,7 @@ WHERE ef.flow_type = 'protocol_fee'
     > CAST ('2024-05-01' AS timestamp)
 GROUP BY 1),
     summary_tipping_fees AS (
-SELECT date_trunc('day', ef.block_time) AS day, SUM (ef.eth_amount) AS tipping_revenue
+SELECT date_trunc('day', ef.block_time) AS day, SUM (ef.value / 1e18) AS tipping_revenue
 FROM dune.towns_protocol.result_towns_eth_flows ef
     JOIN tip_tx tt
 ON ef.tx_hash = tt.tx_hash AND ef."from" = tt.town_address
@@ -35,7 +35,7 @@ WHERE ef.flow_type = 'protocol_fee'
     > CAST ('2024-12-01' AS timestamp)
 GROUP BY 1),
     summary_trading_fees AS (
-SELECT date_trunc('day', ef.block_time) AS day, SUM (ef.eth_amount) AS trading_revenue
+SELECT date_trunc('day', ef.block_time) AS day, SUM (ef.value / 1e18) AS trading_revenue
 FROM dune.towns_protocol.result_towns_eth_flows ef
 WHERE ef.flow_type = 'protocol_fee'
   AND ef."from" = 0x95A2a333D30c8686dE8D01AC464d6034b9aA7b24
@@ -43,7 +43,7 @@ WHERE ef.flow_type = 'protocol_fee'
     > CAST ('2025-05-01' AS timestamp)
 GROUP BY 1),
     summary_other_fees AS (
-SELECT date_trunc('day', ef.block_time) AS day, SUM (ef.eth_amount) AS other_revenue
+SELECT date_trunc('day', ef.block_time) AS day, SUM (ef.value / 1e18) AS other_revenue
 FROM dune.towns_protocol.result_towns_eth_flows ef
 WHERE ef.flow_type = 'protocol_fee'
   AND ef."from" IN (SELECT town_address FROM dune.towns_protocol.result_towns_created)

--- a/queries/towns_created___4223614.sql
+++ b/queries/towns_created___4223614.sql
@@ -1,10 +1,6 @@
 -- part of a query repo
 -- query name: Towns Created
 -- query link: https://dune.com/queries/4223614
-
-
--- query name: towns created
--- query link: https://dune.com/queries/4223614
 -- materialized table: dune.towns_protocol.result_towns_created
 
 SELECT block_time,

--- a/queries/towns_eth_flows___5523291.sql
+++ b/queries/towns_eth_flows___5523291.sql
@@ -4,7 +4,7 @@
 
 
 -- Town ETH Flow Traces - Materialized Table
--- Table: dune.towns_protocol.result_town_traces
+-- Table: dune.towns_protocol.result_towns_eth_flows
 --
 -- IMPORTANT: Flow classification prioritizes protocol fees over town perspective
 -- - Town → Protocol Treasury = 'protocol_fee' (NOT 'town_out')
@@ -19,7 +19,7 @@ SELECT t.tx_hash,
        t.block_number,
        t."from",
        t.to,
-       t.value / 1e18 as eth_amount,
+       t.value,
        CASE
            WHEN t.to = 0x562aA63A64f56245af69b86B4e4be34421f84c81 THEN 'protocol_fee'
            WHEN t.to IN (SELECT town_address FROM towns) THEN 'town_in'


### PR DESCRIPTION
- Replace `eth_amount` with `value / 1e18` for accurate ETH conversions
- Prevent uint256 overflow by dividing before aggregating
- Centralize trading start date with `trading_enabled_date` CTE
- Update table reference and remove unnecessary scaling in `towns_eth_flows`
- Enhance readability, maintainability, and documentation with refined logic and comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added daily calendar with cumulative totals to membership revenue.
  * Introduced configurable trading start date via trading_enabled_date.
* Bug Fixes
  * Standardized ETH units by aggregating value/1e18 across revenue and fees; refined membership revenue/refund/protocol fee filters.
* Refactor
  * Renamed public table to result_towns_eth_flows; output now exposes raw value instead of eth_amount (ETH). May impact downstream consumers.
* Documentation
  * Added critical guidance on ETH aggregation order with correct/incorrect examples.
* Style
  * Minor header and whitespace cleanups in queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->