### PR TITLE
perf: refactor and optimize date filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,10 +180,14 @@ DATE_TRUNC('day', block_time) AS day
 
 - **Select only needed columns**: Avoid `SELECT *` on large tables
 - **Use LIMIT for samples**: Add LIMIT when you only need top-N results
-- **Only sort when necessary**: ORDER BY is expensive on large result sets - omit for materialized tables and intermediate results
+- **Only sort when necessary**: ORDER BY is expensive on large result sets - omit for materialized tables and
+  intermediate results
 - **UNION ALL over UNION**: Avoid deduplication overhead when combining results
 - **Window functions over self-joins**: Use `OVER()` clauses for running totals and ranks
 - **Approximate aggregates**: Use `approx_distinct()` for faster approximate counts when exact precision isn't critical
+- **Multiple scans vs IN clauses**: Combining multiple scans on `base.logs` with IN may not be necessary - sometimes
+  individual `topic0 = hash` filters in separate CTEs can outperform `topic0 IN (hash1, hash2, ...)` but results are
+  highly variable
 
 ### CTE and Subquery Patterns
 

--- a/queries/airdrop_claim_events___5585113.sql
+++ b/queries/airdrop_claim_events___5585113.sql
@@ -30,4 +30,3 @@ WHERE l.contract_address = 0xe55fEE191604cdBeb874F87A28Ca89aED401C303
                    0xf08f338c8905e343697a35fef11af2f611a36658016e0653521354c865373ea7
     )
   AND l.block_date >= DATE '2025-07-15'
-ORDER BY block_number DESC, tx_index DESC, log_index DESC;

--- a/queries/airdrop_claim_events___5585113.sql
+++ b/queries/airdrop_claim_events___5585113.sql
@@ -29,5 +29,5 @@ WHERE l.contract_address = 0xe55fEE191604cdBeb874F87A28Ca89aED401C303
                    0x970af01ab25e63f8131277859b2c17e9a07c2eb257e6db87449000d91c0f8401,
                    0xf08f338c8905e343697a35fef11af2f611a36658016e0653521354c865373ea7
     )
-  AND l.block_time > CAST('2025-07-15' AS timestamp)
+  AND l.block_date >= DATE '2025-07-15'
 ORDER BY block_number DESC, tx_index DESC, log_index DESC;

--- a/queries/approved_operators___5600619.sql
+++ b/queries/approved_operators___5600619.sql
@@ -21,7 +21,7 @@ WITH latest_operator_status AS (SELECT substring(l.topic1 FROM 13)    AS operato
                                 FROM base.logs l
                                 WHERE l.contract_address = 0x7c0422b31401C936172C897802CF0373B35B7698
                                   AND l.topic0 = 0x7db2ae93d80cbf3cf719888318a0b92adff1855bcb01eda517607ed7b0f2183a
-                                  AND l.block_date >= DATE '2024-05-01')
+                                  AND l.block_date >= DATE '2024-05-31')
 
 SELECT status_change_time,
        operator_address,

--- a/queries/approved_operators___5600619.sql
+++ b/queries/approved_operators___5600619.sql
@@ -21,7 +21,7 @@ WITH latest_operator_status AS (SELECT substring(l.topic1 FROM 13)    AS operato
                                 FROM base.logs l
                                 WHERE l.contract_address = 0x7c0422b31401C936172C897802CF0373B35B7698
                                   AND l.topic0 = 0x7db2ae93d80cbf3cf719888318a0b92adff1855bcb01eda517607ed7b0f2183a
-                                  AND l.block_time > CAST('2024-05-01' AS timestamp))
+                                  AND l.block_date >= DATE '2024-05-01')
 
 SELECT status_change_time,
        operator_address,

--- a/queries/delegate_votes_events___5594273.sql
+++ b/queries/delegate_votes_events___5594273.sql
@@ -18,5 +18,5 @@ SELECT l.block_time,
 FROM base.logs l
 WHERE l.contract_address = 0x00000000A22C618fd6b4D7E9A335C4B96B189a38
   AND l.topic0 = 0xdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a724
-  AND l.block_time > CAST('2025-02-01' AS timestamp)
+  AND l.block_date >= DATE '2025-02-01'
 ORDER BY block_number DESC, tx_index DESC, log_index DESC;

--- a/queries/delegate_votes_events___5594273.sql
+++ b/queries/delegate_votes_events___5594273.sql
@@ -19,4 +19,3 @@ FROM base.logs l
 WHERE l.contract_address = 0x00000000A22C618fd6b4D7E9A335C4B96B189a38
   AND l.topic0 = 0xdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a724
   AND l.block_date >= DATE '2025-02-01'
-ORDER BY block_number DESC, tx_index DESC, log_index DESC;

--- a/queries/delegation_proxies___5605080.sql
+++ b/queries/delegation_proxies___5605080.sql
@@ -23,5 +23,5 @@ FROM base.logs l
                   AND se.event_type = 'stake'
 WHERE l.contract_address = 0x7c0422b31401C936172C897802CF0373B35B7698
   AND l.topic0 = 0x9cc45a93930c8a80c99a1f194086c25c0e14b43109f4a5adfd9689aaa703ec4c -- DelegationProxyDeployed
-  AND l.block_time > CAST('2024-12-17' AS timestamp)
+  AND l.block_date >= DATE '2024-12-17'
 ORDER BY deposit_id DESC;

--- a/queries/delegation_proxies___5605080.sql
+++ b/queries/delegation_proxies___5605080.sql
@@ -21,6 +21,7 @@ FROM base.logs l
          JOIN dune.towns_protocol.result_staking_events se
               ON bytearray_to_uint256(l.topic1) = se.deposit_id
                   AND se.event_type = 'stake'
+                  AND l.block_number = se.block_number
 WHERE l.contract_address = 0x7c0422b31401C936172C897802CF0373B35B7698
   AND l.topic0 = 0x9cc45a93930c8a80c99a1f194086c25c0e14b43109f4a5adfd9689aaa703ec4c -- DelegationProxyDeployed
   AND l.block_date >= DATE '2024-12-17'

--- a/queries/membership_subscriptions___5521952.sql
+++ b/queries/membership_subscriptions___5521952.sql
@@ -30,7 +30,7 @@ WITH towns_created AS (SELECT town_address
                                                 0x2f40b0474996b72a4251e00fb9170cdd960deea1dc749772cbbab61395b9b576, -- MembershipTokenIssued
                                                 0x2ec2be2c4b90c2cf13ecb6751a24daed6bb741ae5ed3f7371aabf9402f6d62e8 -- SubscriptionUpdate
                                  )
-                               AND l.block_time > CAST('2024-05-01' AS timestamp)),
+                               AND l.block_date >= DATE '2024-05-01'),
 
 -- Parse mint events
      membership_mints AS (SELECT town_address,

--- a/queries/membership_subscriptions___5521952.sql
+++ b/queries/membership_subscriptions___5521952.sql
@@ -1,63 +1,43 @@
 -- part of a query repo
 -- query name: Membership Subscriptions
 -- query link: https://dune.com/queries/5521952
+-- materialized table: dune.towns_protocol.result_membership_subscriptions
 
 WITH towns_created AS (SELECT town_address
                        FROM dune.towns_protocol.result_towns_created),
 
--- Single pass through base.logs for all membership-related events
-     all_membership_logs AS (SELECT l.contract_address AS town_address,
-                                    l.tx_hash,
-                                    l.block_time,
-                                    l.block_number,
-                                    l.tx_index,
-                                    l.index            AS log_index,
-                                    l.topic0,
-                                    l.topic1,
-                                    l.topic2,
-                                    l.data,
-                                    CASE
-                                        WHEN l.topic0 =
-                                             0x2f40b0474996b72a4251e00fb9170cdd960deea1dc749772cbbab61395b9b576
-                                            THEN 'mint'
-                                        WHEN l.topic0 =
-                                             0x2ec2be2c4b90c2cf13ecb6751a24daed6bb741ae5ed3f7371aabf9402f6d62e8
-                                            THEN 'subscription_update'
-                                        END            AS log_type
-                             FROM base.logs l
-                                      JOIN towns_created tc ON l.contract_address = tc.town_address
-                             WHERE l.topic0 IN (
-                                                0x2f40b0474996b72a4251e00fb9170cdd960deea1dc749772cbbab61395b9b576, -- MembershipTokenIssued
-                                                0x2ec2be2c4b90c2cf13ecb6751a24daed6bb741ae5ed3f7371aabf9402f6d62e8 -- SubscriptionUpdate
-                                 )
-                               AND l.block_date >= DATE '2024-05-01'),
+-- MembershipTokenIssued events
+     membership_mints AS (SELECT l.contract_address             AS town_address,
+                                 l.tx_hash,
+                                 l.block_time,
+                                 l.block_number,
+                                 l.tx_index,
+                                 l.index                        AS log_index,
+                                 substring(l.topic1 FROM 13)    AS member_address,
+                                 bytearray_to_uint256(l.topic2) AS token_id,
+                                 'mint'                         AS event_type
+                          FROM base.logs l
+                                   JOIN towns_created tc ON l.contract_address = tc.town_address
+                          -- MembershipTokenIssued(address indexed recipient, uint256 indexed tokenId)
+                          WHERE l.topic0 = 0x2f40b0474996b72a4251e00fb9170cdd960deea1dc749772cbbab61395b9b576
+                            AND l.block_date >= DATE '2024-05-31'),
 
--- Parse mint events
-     membership_mints AS (SELECT town_address,
-                                 tx_hash,
-                                 block_time,
-                                 block_number,
-                                 tx_index,
-                                 log_index,
-                                 substring(topic1 FROM 13)    AS member_address,
-                                 bytearray_to_uint256(topic2) AS token_id,
-                                 'mint'                       AS event_type
-                          FROM all_membership_logs
-                          WHERE log_type = 'mint'),
+-- SubscriptionUpdate events
+     subscription_updates AS (SELECT l.contract_address                                    AS town_address,
+                                     l.tx_hash,
+                                     l.block_time,
+                                     l.block_number,
+                                     l.tx_index,
+                                     l.index                                               AS log_index,
+                                     bytearray_to_uint256(l.topic1)                        AS token_id,
+                                     bytearray_to_uint256(substring(l.data FROM 1 FOR 32)) AS expiration
+                              FROM base.logs l
+                                       JOIN towns_created tc ON l.contract_address = tc.town_address
+                              -- SubscriptionUpdate(uint256 indexed tokenId, uint64 expiration)
+                              WHERE l.topic0 = 0x2ec2be2c4b90c2cf13ecb6751a24daed6bb741ae5ed3f7371aabf9402f6d62e8
+                                AND l.block_date >= DATE '2024-05-31'),
 
--- Parse subscription update events  
-     subscription_updates AS (SELECT town_address,
-                                     tx_hash,
-                                     block_time,
-                                     block_number,
-                                     tx_index,
-                                     log_index,
-                                     bytearray_to_uint256(topic1)                        AS token_id,
-                                     bytearray_to_uint256(substring(data FROM 1 FOR 32)) AS expiration
-                              FROM all_membership_logs
-                              WHERE log_type = 'subscription_update'),
-
--- Mint events with expiration (join mints with their subscription updates)
+-- Mints with expiration data
      mint_events AS (SELECT mm.block_time,
                             mm.block_number,
                             mm.tx_index,
@@ -74,14 +54,14 @@ WITH towns_created AS (SELECT town_address
                                        AND mm.token_id = su.token_id
                                        AND mm.town_address = su.town_address),
 
--- Renewal events (SubscriptionUpdate events that don't have MembershipTokenIssued in same tx)
+-- Renewals only (no corresponding mint)
      renewal_events AS (SELECT su.block_time,
                                su.block_number,
                                su.tx_index,
                                'renewal' AS event_type,
                                su.town_address,
                                su.token_id,
-                               NULL      AS member_address, -- Cannot determine from renewal events alone
+                               NULL      AS member_address, -- Unknown from renewal events
                                su.expiration,
                                su.tx_hash,
                                su.log_index
@@ -90,10 +70,9 @@ WITH towns_created AS (SELECT town_address
                                            ON su.tx_hash = mm.tx_hash
                                                AND su.token_id = mm.token_id
                                                AND su.town_address = mm.town_address
-                        WHERE mm.tx_hash IS NULL -- Exclude mints
-     ),
+                        WHERE mm.tx_hash IS NULL),
 
--- Union all subscription events
+-- All subscription events
      all_subscription_events AS (SELECT *
                                  FROM mint_events
                                  UNION ALL
@@ -111,4 +90,3 @@ SELECT block_time,
        tx_index,
        log_index
 FROM all_subscription_events
-ORDER BY block_number DESC, tx_index DESC, log_index DESC;

--- a/queries/protocol_fees___5441008.sql
+++ b/queries/protocol_fees___5441008.sql
@@ -19,7 +19,7 @@ FROM dune.towns_protocol.result_towns_eth_flows ef
 ON ef.tx_hash = st.tx_hash AND ef."from" = st.town_address
 WHERE ef.flow_type = 'protocol_fee'
   AND ef.block_time
-    > CAST ('2024-05-01' AS timestamp)
+    > CAST ('2024-05-31' AS timestamp)
 GROUP BY 1),
     summary_tipping_fees AS (
 SELECT date_trunc('day', ef.block_time) AS day, SUM (ef.value / 1e18) AS tipping_revenue
@@ -44,7 +44,7 @@ FROM dune.towns_protocol.result_towns_eth_flows ef
 WHERE ef.flow_type = 'protocol_fee'
   AND ef."from" IN (SELECT town_address FROM dune.towns_protocol.result_towns_created)
   AND ef.block_time
-    > CAST ('2024-05-01' AS timestamp)
+    > CAST ('2024-05-31' AS timestamp)
   AND NOT EXISTS (SELECT 1 FROM subscription_tx st WHERE st.tx_hash = ef.tx_hash)
   AND NOT EXISTS (SELECT 1 FROM tip_tx tt WHERE tt.tx_hash = ef.tx_hash)
 GROUP BY 1),

--- a/queries/proxy_balances___5605600.sql
+++ b/queries/proxy_balances___5605600.sql
@@ -28,7 +28,7 @@ WITH proxy_addresses AS (SELECT DISTINCT proxy_address
                          FROM base.logs l
                          WHERE l.contract_address = 0x00000000A22C618fd6b4D7E9A335C4B96B189a38
                            AND l.topic0 = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef -- Transfer
-                           AND l.block_time > CAST('2024-12-17' AS timestamp)
+                           AND l.block_date >= DATE '2024-12-17'
                            AND (substring(l.topic1 FROM 13) IN (SELECT proxy_address FROM proxy_addresses)
                              OR substring(l.topic2 FROM 13) IN (SELECT proxy_address FROM proxy_addresses))),
 

--- a/queries/proxy_delegations___5605555.sql
+++ b/queries/proxy_delegations___5605555.sql
@@ -25,7 +25,7 @@ WITH proxy_addresses AS (SELECT DISTINCT proxy_address
                             WHERE l.contract_address = 0x00000000A22C618fd6b4D7E9A335C4B96B189a38
                               AND l.topic0 =
                                   0x3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f -- DelegateChanged
-                              AND l.block_time > CAST('2024-12-17' AS timestamp))
+                              AND l.block_date >= DATE '2024-12-17')
 
 SELECT delegator AS proxy_address,
        from_delegate,

--- a/queries/proxy_delegations___5605555.sql
+++ b/queries/proxy_delegations___5605555.sql
@@ -40,4 +40,3 @@ SELECT delegator AS proxy_address,
        log_index
 FROM delegation_changes
 WHERE rn = 1 -- Latest delegation state only
-ORDER BY block_number DESC, log_index DESC;

--- a/queries/staking_events___5589075.sql
+++ b/queries/staking_events___5589075.sql
@@ -103,4 +103,3 @@ WHERE l.contract_address = 0x7c0422b31401C936172C897802CF0373B35B7698
                    0x7e77f685b38c861064cb08f2776eb5dfd3c82f652ed9f21221b8c53b75628e51
     )
   AND l.block_date >= DATE '2024-12-17'
-ORDER BY block_number DESC, tx_index DESC, log_index DESC;

--- a/queries/staking_events___5589075.sql
+++ b/queries/staking_events___5589075.sql
@@ -102,5 +102,5 @@ WHERE l.contract_address = 0x7c0422b31401C936172C897802CF0373B35B7698
                    0x379f5516239c4d5aa59274f4ec7af0b3fe40f0c9abbb4d4ca20bd49f4caa0fcd,
                    0x7e77f685b38c861064cb08f2776eb5dfd3c82f652ed9f21221b8c53b75628e51
     )
-  AND l.block_time > CAST('2024-12-17' AS timestamp)
+  AND l.block_date >= DATE '2024-12-17'
 ORDER BY block_number DESC, tx_index DESC, log_index DESC;

--- a/queries/tip_events___5630852.sql
+++ b/queries/tip_events___5630852.sql
@@ -27,5 +27,5 @@ FROM base.logs l
 WHERE
   -- Tip(uint256 indexed tokenId, address indexed currency, address sender, address receiver, uint256 amount, bytes32 messageId, bytes32 channelId)
     l.topic0 = 0x854db29cbd1986b670c0d596bf56847152a0d66e5ddef710408c1fa4ada78f2b
-  AND l.block_time > CAST('2024-12-01' AS timestamp)
+  AND l.block_date >= DATE '2024-12-01'
 ORDER BY l.block_number DESC, l.tx_index DESC, l.index DESC;

--- a/queries/tip_events___5630852.sql
+++ b/queries/tip_events___5630852.sql
@@ -28,4 +28,3 @@ WHERE
   -- Tip(uint256 indexed tokenId, address indexed currency, address sender, address receiver, uint256 amount, bytes32 messageId, bytes32 channelId)
     l.topic0 = 0x854db29cbd1986b670c0d596bf56847152a0d66e5ddef710408c1fa4ada78f2b
   AND l.block_date >= DATE '2024-12-01'
-ORDER BY l.block_number DESC, l.tx_index DESC, l.index DESC;

--- a/queries/tip_traces___5627232.sql
+++ b/queries/tip_traces___5627232.sql
@@ -18,10 +18,9 @@ SELECT t.block_time,
        t.value,
        SUBSTRING(t.input FROM 1 FOR 4) AS function_selector
 FROM base.traces t
-         JOIN towns_created tc ON t.to = tc.town_address
-WHERE t.success = true
+WHERE t.block_date >= DATE '2024-12-01'
+  AND t.success
   AND t.call_type = 'call'
   AND t.value > 0
-  AND t.block_time > CAST('2024-12-01' AS timestamp)
+  AND t.to IN (SELECT town_address FROM towns_created)
   AND SUBSTRING(t.input FROM 1 FOR 4) IN (0x89b10db8, 0xc46be00e)
-ORDER BY t.block_time DESC;

--- a/queries/tipping_revenue___5440873.sql
+++ b/queries/tipping_revenue___5440873.sql
@@ -27,7 +27,7 @@ WITH tip_events AS (SELECT block_time,
                                                ON t.tx_hash = tt.tx_hash
                                                    AND t."from" = tt.town_address
                                  WHERE t.to = 0x562aA63A64f56245af69b86B4e4be34421f84c81
-                                   AND t.success = true
+                                   AND t.success
                                    AND t.call_type = 'call'
                                    AND t.value > 0
                                    AND t.block_time > cast('2024-12-01' AS timestamp)),

--- a/queries/towns_created___4223614.sql
+++ b/queries/towns_created___4223614.sql
@@ -16,5 +16,5 @@ WHERE
     contract_address = 0x9978c826d93883701522d2CA645d5436e5654252
   -- SpaceCreated(address,uint256,address)
   AND topic0 = 0xe50fc3942f8a2d7e5a7c8fb9488499eba5255b41e18bc3f1b4791402976d1d0b
-  AND block_time > CAST('2024-05-31' AS timestamp)
+  AND block_date >= DATE '2024-05-31'
 ORDER BY town_owner_token_id DESC;

--- a/queries/towns_eth_flows___5523291.sql
+++ b/queries/towns_eth_flows___5523291.sql
@@ -27,7 +27,7 @@ SELECT t.tx_hash,
            ELSE 'other'
            END as flow_type
 FROM base.traces t
-WHERE t.block_date >= DATE '2024-05-01'
+WHERE t.block_date >= DATE '2024-05-31'
   AND t.success
   AND t.call_type = 'call'
   AND t.value > 0

--- a/queries/towns_eth_flows___5523291.sql
+++ b/queries/towns_eth_flows___5523291.sql
@@ -25,15 +25,14 @@ SELECT t.tx_hash,
            WHEN t.to IN (SELECT town_address FROM towns) THEN 'town_in'
            WHEN t."from" IN (SELECT town_address FROM towns) THEN 'town_out'
            ELSE 'other'
-           END        as flow_type
+           END as flow_type
 FROM base.traces t
-WHERE t.success = true
+WHERE t.block_date >= DATE '2024-05-01'
+  AND t.success
   AND t.call_type = 'call'
   AND t.value > 0
-  AND t.block_time > CAST('2024-05-01' AS timestamp)
   AND (
     t.to IN (SELECT town_address FROM towns)
         OR t."from" IN (SELECT town_address FROM towns)
         OR t.to = 0x562aA63A64f56245af69b86B4e4be34421f84c81
     )
-ORDER BY t.block_time DESC;

--- a/queries/trading_volume_in_town___5440133.sql
+++ b/queries/trading_volume_in_town___5440133.sql
@@ -32,7 +32,7 @@ WITH trading_enabled_date AS (SELECT CAST('2025-05-01' AS timestamp) AS trading_
                                 FROM base.traces t
                                 WHERE t."from" = 0x95A2a333D30c8686dE8D01AC464d6034b9aA7b24
                                   AND t.to = 0x562aA63A64f56245af69b86B4e4be34421f84c81
-                                  AND t.success = true
+                                  AND t.success
                                   AND t.call_type = 'call'
                                   AND t.value > 0
                                   AND t.block_time > (SELECT trading_start FROM trading_enabled_date)),


### PR DESCRIPTION
**Is this linked to an existing issue**
If so, link that issue(s) here.

**Fill out the following table describing your edits:**

| Original | Updated | Change | Reasoning |
|---|---|---|---|
| N/A | N/A | Refactor date filtering to use `block_date` consistently | Align with standardized query practices and improve performance |
| N/A | N/A | Removed unnecessary `ORDER BY` clauses | Enhanced performance by eliminating redundant clauses in non-deterministic queries |
| N/A | N/A | Simplified membership subscription logic | Improved maintainability and consistency in event parsing |

**Provide any other context or screenshots that explain or justify the changes above:**

- Standardized `block_date` usage to improve query readability and performance.
- Optimized staking query joins for consistent proxy delegation results.
- Updated code to comply with recent optimization guidelines, enhancing maintainability.

---

**Note to Contributor:**

Make sure your PR edits the original `query_id.sql` file with the new query text. If you are proposing adding a new query completely, make sure to add it to `queries.yml` and as a file in `/queries` as well.

Thanks for contributing! 🙏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced membership and subscription event reporting by unifying mints and renewals into a consistent output with clearer fields.
- Refactor
  - Standardized date-based filtering across multiple reports (switch from time to date comparisons) and aligned cutoff dates.
  - Removed explicit ordering in several queries to streamline results.
  - Simplified success checks to boolean truthiness in select traces.
- Bug Fixes
  - Improved join and filtering logic to better align related events and prevent mismatches.
- Documentation
  - Clarified query writing best practices with expanded guidance.
- Style
  - Minor formatting cleanups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->